### PR TITLE
use pickle for serialization/deserialization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from redis import Redis
 
 @pytest.fixture
 def redis():
-    redis_db = Redis(host="localhost", port="6379", db=0, encoding="utf-8", decode_responses=True)
+    redis_db = Redis(host="localhost", port="6379", db=0, encoding="utf-8", decode_responses=False)
     assert redis_db.ping()
     
     return redis_db

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -14,7 +14,7 @@ def test_ttl(redis):
     key1 = r_ttl.redis_key("1")
     r_ttl[key1] = "1"
 
-    assert r_ttl[key1] == redis.get(key1)
+    assert r_ttl[key1] == RedisTTL.deserialize(redis.get(key1))
     assert r_ttl[key1] == "1"
     assert len(r_ttl) == 1
 
@@ -23,7 +23,7 @@ def test_ttl(redis):
     key2 = r_ttl.redis_key("2")
     r_ttl[key2] = "2"
 
-    assert r_ttl[key2] == redis.get(key2)
+    assert r_ttl[key2] == RedisTTL.deserialize(redis.get(key2))
     assert r_ttl[key2] == "2"
     assert len(r_ttl) == 2
 
@@ -34,7 +34,7 @@ def test_ttl(redis):
 
     time.sleep(1)
 
-    assert not key2 in r_ttl    
+    assert not key2 in r_ttl
     assert len(r_ttl) == 0
 
 def test_ttl_invalidate(redis):
@@ -46,7 +46,7 @@ def test_ttl_invalidate(redis):
     )
 
     key1 = r_ttl.redis_key("1")
-    r_ttl[key1] = "1"
+    r_ttl[key1] = RedisTTL.serialize("1")
 
     assert len(r_ttl) == 1
 
@@ -78,23 +78,22 @@ def test_redis_lru(redis):
 
     with pytest.raises(KeyError):
         for x in range(3):
-            redis.set(r_lru.redis_key(x), x)
-        
+            encoded_x = RedisLRU.serialize(x)
+            redis.set(r_lru.redis_key(x), encoded_x)
+
         r_lru[key1] = "1"
-        
+
     r_lru.invalidateAll()
     assert len(r_lru) == 0
 
     r_lru[key1] = "1"
 
-    assert r_lru[key1] == redis.get(key1)
-    assert r_lru[key1] == "1"
-    assert len(r_lru) == 1
+    assert r_lru[key1] == RedisLRU.deserialize(redis.get(key1))
 
     key2 = r_lru.redis_key("2-1")
     r_lru[key2] = "2"
 
-    assert r_lru[key2] == redis.get(key2)
+    assert r_lru[key2] == RedisLRU.deserialize(redis.get(key2))
     assert r_lru[key2] == "2"
     assert len(r_lru) == 2
 


### PR DESCRIPTION
All test are passing, I had to modify them a bit to make it compatible with the new data type stored because the data in redis is now binary type. I had to also change the redis initialization in tests - otherwise it wanted to cast the binary to string which we don't want instead we want to decode it ourselves. The only problem now is that the new data its not compatible with old data stored in redis so it probably needs to be a major version change.
I found an example that also [serializes the keys](https://stackoverflow.com/questions/15219858/how-to-store-a-complex-object-in-redis-using-redis-py) its somewhere in the middle of the page. This may be useful also at some point.
Tomorrow I will test it with my code I wrote last week. Only problem is that we are running currently 3.5 and it wont install on this version. I had to copy the files.